### PR TITLE
Fixed QR-codes with non-latin chars via API version update.

### DIFF
--- a/src/GroupDocs.Signature.MVC.csproj
+++ b/src/GroupDocs.Signature.MVC.csproj
@@ -45,8 +45,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Signature, Version=20.3.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Signature.20.3.0\lib\net20\GroupDocs.Signature.dll</HintPath>
+    <Reference Include="GroupDocs.Signature, Version=20.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Signature.20.4.0\lib\net20\GroupDocs.Signature.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -54,7 +54,7 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="GroupDocs.Signature" version="20.3.0" targetFramework="net45" />
+  <package id="GroupDocs.Signature" version="20.4.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
@@ -16,7 +16,7 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="Node-Kit" version="11.1.0.1" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />


### PR DESCRIPTION
**Problem:**
We met error `Object reference not set to an instance of an object` during generating the QR-code image using the non-latin char-set.

**Solution:**
This issue was fixed in the 20.4 version of the Signature library, so library version in the app was updated.

**Tests:**
The creation of the QR-code basing on non-latin chars was manually tested.